### PR TITLE
Update nu-plugin dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/oderwat/nu_plugin_logfmt
 
 go 1.23.3
 
-require github.com/ainvaltin/nu-plugin v0.0.0-20250101160226-8ced7b8dab20
+require github.com/ainvaltin/nu-plugin v0.0.0-20250114192936-844824d8678c
 
 require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect


### PR DESCRIPTION
As per [this issue](https://github.com/ainvaltin/nu-plugin/issues/3), installation of `nu_plugin_logfmt` on Windows fails because of `nu-plugin` error. This has now been fixed by the latest commit, which I'm now pointing to in `go.mod`.

I don't use Go so I'm not entirely sure if this change is enough to update the package.